### PR TITLE
Chore/underscore validation noplurality

### DIFF
--- a/HuduAPI/HuduAPI.psd1
+++ b/HuduAPI/HuduAPI.psd1
@@ -12,7 +12,7 @@
     RootModule        = '.\HuduAPI.psm1'
 
     # Version number of this module.
-    ModuleVersion     = '3.14.15'
+    ModuleVersion     = '3.2.25'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()
@@ -33,7 +33,7 @@
     Description       = 'This module provides an interface to the Hudu Rest API further information can be found at https://github.com/lwhitelock/HuduAPI'
 
     # Minimum version of the Windows PowerShell engine required by this module
-    PowerShellVersion = '7.0'
+    PowerShellVersion = '7.5.1'
 
     # Name of the Windows PowerShell host required by this module
     # PowerShellHostName = ''

--- a/HuduAPI/HuduAPI.psm1
+++ b/HuduAPI/HuduAPI.psm1
@@ -7,6 +7,6 @@ foreach ($import in @($Public)) {
     }
 }
 $script:AssetLayoutsCache     = $null
-$script:AssetLayoutsCacheTtl  = [TimeSpan]::FromMinutes(5)
+$script:AssetLayoutsCacheTtl  = [TimeSpan]::FromMinutes(2)
 
 Export-ModuleMember -Function $Public.BaseName -Alias *

--- a/HuduAPI/HuduAPI.psm1
+++ b/HuduAPI/HuduAPI.psm1
@@ -6,4 +6,7 @@ foreach ($import in @($Public)) {
         Write-Error -Message "Failed to import function $($import.FullName): $_"
     }
 }
+$script:AssetLayoutsCache     = $null
+$script:AssetLayoutsCacheTtl  = [TimeSpan]::FromMinutes(5)
+
 Export-ModuleMember -Function $Public.BaseName -Alias *

--- a/HuduAPI/Private/Validate-Fields.ps1
+++ b/HuduAPI/Private/Validate-Fields.ps1
@@ -175,6 +175,7 @@ function Get-SanitizedAssetLayout {
         [Parameter(Mandatory)][string]$AssetLayoutId
     )
     $updatedFields = @()
+    $ReplaceWith=" "
     $rxU = [regex]'_+'
     $rxS = [regex]'\s{2,}'
     $layout   = $null

--- a/HuduAPI/Private/Validate-Fields.ps1
+++ b/HuduAPI/Private/Validate-Fields.ps1
@@ -140,27 +140,9 @@ function Get-SanitizedAssetLayout {
     $ReplaceWith=" "
     $rxU = [regex]'_+'
     $rxS = [regex]'\s{2,}'
-    $layout   = $null
-    $now      = Get-Date
-    $isFresh  = $false
+    $layout = Get-HuduAssetLayoutsCached -LayoutId $AssetLayoutId
+    $layout = $layout.data.asset_layout ?? $layout.asset_layout ?? $layout
 
-    # ---------- Try cache first ----------
-    if ($script:AssetLayoutsCache -and $script:AssetLayoutsCache.CachedAt) {
-        $isFresh = (($now - $script:AssetLayoutsCache.CachedAt) -lt $script:AssetLayoutsCacheTtl)
-        if ($isFresh) {
-            $layout = $script:AssetLayoutsCache.Data | Where-Object { $_.id -eq $AssetLayoutId }
-        }
-    }
-
-    # ---------- LIVE FETCH PATH (no cache, stale cache, or cache miss) ----------
-    if (-not $layout) {
-        try {
-            $layout = Get-HuduAssetLayouts -Id $AssetLayoutId
-            $layout = $layout.asset_layout ?? $layout
-        } catch {
-            return $null
-        }
-      }
     if (-not $layout -or -not $layout.fields) { return $layout }
 
   # Build sanitized fields as hashtable[]

--- a/HuduAPI/Private/Validate-Fields.ps1
+++ b/HuduAPI/Private/Validate-Fields.ps1
@@ -342,3 +342,4 @@ function Remove-UnderscoresInFields {
 
   end { $out }
 }
+}

--- a/HuduAPI/Private/Validate-Fields.ps1
+++ b/HuduAPI/Private/Validate-Fields.ps1
@@ -1,3 +1,28 @@
+function Normalize-Text {
+    param([string]$s)
+    if ([string]::IsNullOrWhiteSpace($s)) { return $null }
+    $s = $s.Trim().ToLowerInvariant()
+    $s = [regex]::Replace($s, '[\s_-]+', ' ')  # "primary_email" -> "primary email"
+    # strip diacritics (prénom -> prenom)
+    $formD = $s.Normalize([System.Text.NormalizationForm]::FormD)
+    $sb = New-Object System.Text.StringBuilder
+    foreach ($ch in $formD.ToCharArray()){
+        if ([System.Globalization.CharUnicodeInfo]::GetUnicodeCategory($ch) -ne
+            [System.Globalization.UnicodeCategory]::NonSpacingMark) { [void]$sb.Append($ch) }
+    }
+    ($sb.ToString()).Normalize([System.Text.NormalizationForm]::FormC)
+}
+function Test-Equiv {
+    param([string]$A, [string]$B)
+    $a = Normalize-Text $A; $b = Normalize-Text $B
+    if (-not $a -or -not $b) { return $false }
+    if ($a -eq $b) { return $true }
+    $reA = "(^| )$([regex]::Escape($a))( |$)"
+    $reB = "(^| )$([regex]::Escape($b))( |$)"
+    if ($b -match $reA -or $a -match $reB) { return $true } 
+    if ($a.Replace(' ', '') -eq $b.Replace(' ', '')) { return $true }
+    return $false
+}
 
 function Get-HuduAssetLayoutsCached {
     [CmdletBinding()]

--- a/HuduAPI/Private/Validate-Fields.ps1
+++ b/HuduAPI/Private/Validate-Fields.ps1
@@ -23,6 +23,37 @@ function Test-Equiv {
     if ($a.Replace(' ', '') -eq $b.Replace(' ', '')) { return $true }
     return $false
 }
+
+function Set-LayoutsCacheMarkedDirty {
+<#
+.SYNOPSIS
+Mark the Asset Layouts cache as stale (or wipe it).
+
+.PARAMETER Hard
+Also clears cached data and the legacy $script:AssetLayouts list.
+#>
+    [CmdletBinding()]
+    param([switch]$Hard)
+
+    if (-not $script:AssetLayoutsCache) {
+        $script:AssetLayoutsCache = [pscustomobject]@{
+            Data     = @()
+            CachedAt = $null
+        }
+        $script:AssetLayouts = @()
+        return $script:AssetLayoutsCache
+    }
+
+    # Mark NOT fresh (stale) but keep data by default
+    $script:AssetLayoutsCache.CachedAt = $null
+
+    if ($Hard) {
+        $script:AssetLayoutsCache.Data = @()
+        $script:AssetLayouts = @()
+    }
+
+    return $script:AssetLayoutsCache
+}
 function Add-HuduAssetLayoutsToCache {
 <#
 .SYNOPSIS

--- a/HuduAPI/Private/Validate-Fields.ps1
+++ b/HuduAPI/Private/Validate-Fields.ps1
@@ -11,7 +11,7 @@ function Get-HuduAssetLayoutsCached {
     $now     = Get-Date
     $isFresh = $false
     if ($script:AssetLayoutsCache) {
-        $isFresh = ($script:AssetLayoutsCache.CachedAt -ne $null) -and
+        $isFresh = ($null -ne $script:AssetLayoutsCache.CachedAt) -and
                    (($now - $script:AssetLayoutsCache.CachedAt) -lt $script:AssetLayoutsCacheTtl)
     }
 

--- a/HuduAPI/Private/Validate-Fields.ps1
+++ b/HuduAPI/Private/Validate-Fields.ps1
@@ -1,0 +1,157 @@
+function Get-SanitizedAssetLayout {
+    [CmdletBinding(SupportsShouldProcess)]
+    param(
+        [Parameter(Mandatory)][string]$AssetLayoutId
+    )
+    $layout = $null
+    try {
+        $layout = get-huduassetlayout -id $assetlayoutid
+        $layout = $layout.asset_layout ?? $layout
+    } catch {return $null}
+    if (-not $layout) { return $null }
+
+    # Detect if any label actually contains underscores
+    $hasUnders = $false
+    if ($layout.fields) {
+        $hasUnders = @(
+            $layout.fields |
+            ForEach-Object { $_.label } |
+            Where-Object { $_ -is [string] -and $_ -match '_' }
+        ).Count -gt 0
+    }
+
+    if ($hasUnders) {
+        write-host "warn- underscores present in layout"
+        $updatedFields = $layout.fields | Remove-UnderscoresInFields -IsLayout
+
+        $oldJson = $layout.fields    | ConvertTo-Json -Depth 50 -Compress
+        $newJson = $updatedFields    | ConvertTo-Json -Depth 50 -Compress
+        $changed = ($oldJson -ne $newJson)
+
+        if ($changed -and $PSCmdlet.ShouldProcess("AssetLayout $AssetLayoutId","Replace underscores in labels")) {
+            $null = Set-HuduAssetLayout -Id $AssetLayoutId -Fields $updatedFields
+            $layout = Get-HuduAssetLayouts -Id $AssetLayoutId
+            $layout = $layout.asset_layout ?? $layout
+            write-host "layout updated to not include underscores in fields."
+        }
+    }
+    return $layout
+}
+
+function Get-ValidatedAssetFields {
+    param (
+        [array]$fields,
+        [int]$assetLayoutId
+    )
+    $layout = Get-SanitizedAssetLayout -AssetLayoutId $assetLayoutId
+    if (-not $layout) { return @() }
+
+    $layoutLabelSet = @($layout.fields.label)
+
+    $validatedFields = foreach ($field in $fields) {
+        $matched = $false
+        foreach ($layoutLabel in $layoutLabelSet) {
+            if (Test-Equiv -A $field.label -B $layoutLabel) {
+                # shallow clone to avoid mutating original
+                $updated = @()
+                if ($field -is [PSCustomObject]){
+                    foreach ($p in $field.PSObject.Properties) {
+                        $updated+= @{$p.Name = $p.Value}
+                    }
+                } else {
+                    $updated = $field.clone()
+                }
+                $updated.label = $layoutLabel
+                $matched = $true
+                $updated
+                break
+            }
+        }
+        if (-not $matched) { $field }
+    }
+    return $($validatedFields | Remove-UnderscoresInFields)
+}
+
+
+function Remove-UnderscoresInFields {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory, ValueFromPipeline)]
+        $Fields,
+
+        # Only clean the "label" property in asset layout field objects
+        [switch]$IsLayout,
+
+        # Default is a space; coerced to string to prevent $true -> "True"
+        [string]$ReplaceWith = ' ',
+
+        # Optionally drop null/empty values
+        [switch]$DropNullValues
+    )
+
+    begin {
+        # Coerce once; guarantees string even if caller passed a bool accidentally
+        $Replacement = [string]$ReplaceWith
+
+        function As-Enumerable($x) {
+            if ($null -eq $x) { @() }
+            elseif ($x -is [System.Collections.IEnumerable] -and -not ($x -is [string])) { $x }
+            else { ,$x }
+        }
+        function Get-Pairs($obj) {
+            if ($obj -is [System.Collections.IDictionary]) {
+                $obj.GetEnumerator() | ForEach-Object {
+                    [PSCustomObject]@{ Name = $_.Key; Value = $_.Value }
+                }
+            } else {
+                $obj.PSObject.Properties | ForEach-Object {
+                    [PSCustomObject]@{ Name = $_.Name; Value = $_.Value }
+                }
+            }
+        }
+        function Is-Empty([object]$v) {
+            if ($null -eq $v) { return $true }
+            if ($v -is [string]) { return [string]::IsNullOrWhiteSpace($v) }
+            return $false
+        }
+    }
+
+    process {
+        $out = @()
+
+        foreach ($f in (As-Enumerable $Fields)) {
+            if ($null -eq $f) { continue }
+
+            if ($IsLayout) {
+                # Only touch "label"
+                $new = [ordered]@{}
+                foreach ($p in Get-Pairs $f) {
+                    if ($p.Name -eq 'label' -and $p.Value -is [string]) {
+                        $new['label'] = $p.Value.Replace('_', $Replacement).Trim()
+                    } else {
+                        if ($DropNullValues) {
+                            if (-not (Is-Empty $p.Value)) { $new[$p.Name] = $p.Value }
+                        } else {
+                            $new[$p.Name] = $p.Value
+                        }
+                    }
+                }
+                $out += $new
+            } else {
+                # Transform ALL keys
+                $new = [ordered]@{}
+                foreach ($p in Get-Pairs $f) {
+                    $newKey = ($p.Name.ToString()).Replace('_', $Replacement).Trim()
+                    if ($DropNullValues) {
+                        if (-not (Is-Empty $p.Value)) { $new[$newKey] = $p.Value }
+                    } else {
+                        $new[$newKey] = $p.Value
+                    }
+                }
+                $out += $new
+            }
+        }
+
+        $out
+    }
+}

--- a/HuduAPI/Public/Get-HuduAssetLayouts.ps1
+++ b/HuduAPI/Public/Get-HuduAssetLayouts.ps1
@@ -36,7 +36,7 @@ function Get-HuduAssetLayouts {
         $HuduRequest.Resource = '{0}/{1}' -f $HuduRequest.Resource, $LayoutId
         $AssetLayout = Invoke-HuduRequest @HuduRequest
         Add-HuduAssetLayoutsToCache -Layout $($AssetLayout.asset_layout ?? $AssetLayout)
-        return $AssetLayout.asset_layout
+        return $AssetLayout
     } else {
         $Params = @{}
         if ($Name) { $Params.name = $Name }
@@ -49,6 +49,6 @@ function Get-HuduAssetLayouts {
             $script:AssetLayouts = $AssetLayouts | Sort-Object -Property name
             Add-HuduAssetLayoutsToCache -Layout $AssetLayouts -MarkFresh
         }
-        $AssetLayouts
+        return $AssetLayouts
     }
 }

--- a/HuduAPI/Public/Get-HuduAssetLayouts.ps1
+++ b/HuduAPI/Public/Get-HuduAssetLayouts.ps1
@@ -35,7 +35,7 @@ function Get-HuduAssetLayouts {
     if ($LayoutId) {
         $HuduRequest.Resource = '{0}/{1}' -f $HuduRequest.Resource, $LayoutId
         $AssetLayout = Invoke-HuduRequest @HuduRequest
-        return $AssetLayout
+        return $AssetLayout.asset_layout 
     } else {
         $Params = @{}
         if ($Name) { $Params.name = $Name }

--- a/HuduAPI/Public/Get-HuduAssetLayouts.ps1
+++ b/HuduAPI/Public/Get-HuduAssetLayouts.ps1
@@ -35,7 +35,6 @@ function Get-HuduAssetLayouts {
     if ($LayoutId) {
         $HuduRequest.Resource = '{0}/{1}' -f $HuduRequest.Resource, $LayoutId
         $AssetLayout = Invoke-HuduRequest @HuduRequest
-        if ($null -ne $AssetLayout) {Add-HuduAssetLayoutsToCache -Layout $AssetLayout} else {Set-LayoutsCacheMarkedDirty}
         return $AssetLayout
     } else {
         $Params = @{}

--- a/HuduAPI/Public/Get-HuduAssetLayouts.ps1
+++ b/HuduAPI/Public/Get-HuduAssetLayouts.ps1
@@ -35,6 +35,8 @@ function Get-HuduAssetLayouts {
     if ($LayoutId) {
         $HuduRequest.Resource = '{0}/{1}' -f $HuduRequest.Resource, $LayoutId
         $AssetLayout = Invoke-HuduRequest @HuduRequest
+        if ($AssetLayout) {Add-HuduAssetLayoutsToCache -Layout $AssetLayout.asset_layout}
+
         return $AssetLayout.asset_layout 
     } else {
         $Params = @{}

--- a/HuduAPI/Public/Get-HuduAssetLayouts.ps1
+++ b/HuduAPI/Public/Get-HuduAssetLayouts.ps1
@@ -35,7 +35,7 @@ function Get-HuduAssetLayouts {
     if ($LayoutId) {
         $HuduRequest.Resource = '{0}/{1}' -f $HuduRequest.Resource, $LayoutId
         $AssetLayout = Invoke-HuduRequest @HuduRequest
-        Add-HuduAssetLayoutsToCache -Layout $($AssetLayout.asset_layout ?? $AssetLayout)
+        if ($null -ne $AssetLayout) {Add-HuduAssetLayoutsToCache -Layout $AssetLayout} else {Set-LayoutsCacheMarkedDirty}
         return $AssetLayout
     } else {
         $Params = @{}
@@ -47,7 +47,7 @@ function Get-HuduAssetLayouts {
 
         if (!$Name -and !$Slug) {
             $script:AssetLayouts = $AssetLayouts | Sort-Object -Property name
-            Add-HuduAssetLayoutsToCache -Layout $AssetLayouts -MarkFresh
+            if ($AssetLayouts -and $AssetLayouts.count -gt 0) {Add-HuduAssetLayoutsToCache -Layout $AssetLayouts -MarkFresh} else {Set-LayoutsCacheMarkedDirty}
         }
         return $AssetLayouts
     }

--- a/HuduAPI/Public/Get-HuduAssetLayouts.ps1
+++ b/HuduAPI/Public/Get-HuduAssetLayouts.ps1
@@ -1,4 +1,24 @@
 function Get-HuduAssetLayouts {
+    <#
+    .SYNOPSIS
+    Get a list of Asset Layouts
+
+    .DESCRIPTION
+    Call Hudu API to retrieve asset layouts for server
+
+    .PARAMETER Name
+    Filter by name of Asset Layout
+
+    .PARAMETER LayoutId
+    Id of Asset Layout
+
+    .PARAMETER Slug
+    Filter by url slug
+
+    .EXAMPLE
+    Get-HuduAssetLayouts -Name 'Contacts'
+
+    #>
     [CmdletBinding()]
     Param (
         [String]$Name,
@@ -14,61 +34,21 @@ function Get-HuduAssetLayouts {
 
     if ($LayoutId) {
         $HuduRequest.Resource = '{0}/{1}' -f $HuduRequest.Resource, $LayoutId
-        $resp   = Invoke-HuduRequest @HuduRequest
-        $layout = $resp.asset_layout ?? $resp
-
-        # lazily merge into cache (do NOT bump CachedAt so partial refreshes don't mark cache "fresh")
-        if ($layout) {
-            if ($script:AssetLayoutsCache -and $script:AssetLayoutsCache.Data) {
-                $data = @($script:AssetLayoutsCache.Data | Where-Object { $_.id -ne $layout.id })
-                $data += $layout
-                $script:AssetLayoutsCache.Data = $data | Sort-Object -Property name
-            } else {
-                $script:AssetLayoutsCache = [pscustomobject]@{
-                    Data     = @($layout)
-                    CachedAt = $null   # not a full refresh
-                }
-            }
-            # keep legacy var for completers in sync
-            $script:AssetLayouts = $script:AssetLayoutsCache.Data
-        }
-
-        return $layout
-    }
-    else {
+        $AssetLayout = Invoke-HuduRequest @HuduRequest
+        Add-HuduAssetLayoutsToCache -Layout $($AssetLayout.asset_layout ?? $AssetLayout)
+        return $AssetLayout.asset_layout
+    } else {
         $Params = @{}
         if ($Name) { $Params.name = $Name }
         if ($Slug) { $Params.slug = $Slug }
-        if ($Params.Count -gt 0) { $HuduRequest.Params = $Params }
+        $HuduRequest.Params = $Params
 
-        $items = Invoke-HuduRequestPaginated -HuduRequest $HuduRequest -Property 'asset_layouts' -PageSize 25
+        $AssetLayouts = Invoke-HuduRequestPaginated -HuduRequest $HuduRequest -Property 'asset_layouts' -PageSize 25
 
-        if ($Params.Count -eq 0) {
-            $sorted = $items | Sort-Object -Property name
-            $script:AssetLayoutsCache = [pscustomobject]@{
-                Data     = $sorted
-                CachedAt = Get-Date
-            }
-            $script:AssetLayouts = $sorted # for your completer
-        } else {
-            # FILTERED SET: merge, but don't bump timestamp
-            if ($items) {
-                if ($script:AssetLayoutsCache -and $script:AssetLayoutsCache.Data) {
-                    # replace (or add) by id
-                    $byId = @{}
-                    foreach ($x in $script:AssetLayoutsCache.Data) { $byId[$x.id] = $x }
-                    foreach ($x in $items)                         { $byId[$x.id] = $x }
-                    $script:AssetLayoutsCache.Data = $byId.Values | Sort-Object -Property name
-                } else {
-                    $script:AssetLayoutsCache = [pscustomobject]@{
-                        Data     = $items
-                        CachedAt = $null
-                    }
-                }
-                $script:AssetLayouts = $script:AssetLayoutsCache.Data
-            }
+        if (!$Name -and !$Slug) {
+            $script:AssetLayouts = $AssetLayouts | Sort-Object -Property name
+            Add-HuduAssetLayoutsToCache -Layout $AssetLayouts -MarkFresh
         }
-
-        return $items
+        $AssetLayouts
     }
 }

--- a/HuduAPI/Public/New-HuduAsset.ps1
+++ b/HuduAPI/Public/New-HuduAsset.ps1
@@ -89,7 +89,8 @@ function New-HuduAsset {
 
 
     if ($Fields) {
-        $Fields | Remove-UnderscoresInFields
+        $validatedFields = Convert-AssetFieldsToCanonical -Fields $Fields -AssetLayoutId $AssetLayoutId `
+                                -DropUnmatched -DropNull
         $Asset.asset.add('custom_fields', $validatedFields)
     }
 

--- a/HuduAPI/Public/New-HuduAsset.ps1
+++ b/HuduAPI/Public/New-HuduAsset.ps1
@@ -89,7 +89,7 @@ function New-HuduAsset {
 
 
     if ($Fields) {
-        $validatedFields = Get-ValidatedAssetFields -Fields $Fields -AssetLayoutId $AssetLayoutId
+        $Fields | Remove-UnderscoresInFields
         $Asset.asset.add('custom_fields', $validatedFields)
     }
 

--- a/HuduAPI/Public/New-HuduAsset.ps1
+++ b/HuduAPI/Public/New-HuduAsset.ps1
@@ -90,7 +90,7 @@ function New-HuduAsset {
 
     if ($Fields) {
         $validatedFields = Convert-AssetFieldsToCanonical -Fields $Fields -AssetLayoutId $AssetLayoutId `
-                                -DropUnmatched -DropNull
+                                -DropUnmatched
         $Asset.asset.add('custom_fields', $validatedFields)
     }
 

--- a/HuduAPI/Public/New-HuduAsset.ps1
+++ b/HuduAPI/Public/New-HuduAsset.ps1
@@ -87,8 +87,10 @@ function New-HuduAsset {
         $Asset.asset.add('primary_manufacturer', $PrimaryManufacturer)
     }
 
+
     if ($Fields) {
-        $Asset.asset.add('custom_fields', $Fields)
+        $validatedFields = Get-ValidatedAssetFields -Fields $Fields -AssetLayoutId $AssetLayoutId
+        $Asset.asset.add('custom_fields', $validatedFields)
     }
 
     if ($Slug) {

--- a/HuduAPI/Public/New-HuduAssetLayout.ps1
+++ b/HuduAPI/Public/New-HuduAssetLayout.ps1
@@ -152,6 +152,9 @@ function New-HuduAssetLayout {
     Write-Verbose $JSON
 
     if ($PSCmdlet.ShouldProcess($Name)) {
-        Invoke-HuduRequest -Method post -Resource '/api/v1/asset_layouts' -Body $JSON
+        $result = Invoke-HuduRequest -Method post -Resource '/api/v1/asset_layouts' -Body $JSON
+        $NewLayout = Get-HuduAssetLayouts -id $($result.asset_layout.id ?? $result.id)
+        Add-HuduAssetLayoutsToCache -Layout $($NewLayout.asset_layout ?? $NewLayout)
+        return $result
     }
 }

--- a/HuduAPI/Public/New-HuduAssetLayout.ps1
+++ b/HuduAPI/Public/New-HuduAssetLayout.ps1
@@ -119,7 +119,7 @@ function New-HuduAssetLayout {
     $AssetLayout.asset_layout.add('icon', $Icon)
     $AssetLayout.asset_layout.add('color', $Color)
     $AssetLayout.asset_layout.add('icon_color', $IconColor)
-    $validatedFields = $Fields | Remove-UnderscoresInFields -NewLayout
+    $validatedFields = $Fields | Remove-UnderscoresInFields -isLayout
     $AssetLayout.asset_layout.add('fields', $validatedFields)
     #$AssetLayout.asset_layout.add('active', $Active)
 

--- a/HuduAPI/Public/New-HuduAssetLayout.ps1
+++ b/HuduAPI/Public/New-HuduAssetLayout.ps1
@@ -119,7 +119,8 @@ function New-HuduAssetLayout {
     $AssetLayout.asset_layout.add('icon', $Icon)
     $AssetLayout.asset_layout.add('color', $Color)
     $AssetLayout.asset_layout.add('icon_color', $IconColor)
-    $AssetLayout.asset_layout.add('fields', $Fields)
+    $validatedFields = Remove-UnderscoresInFields -Fields $Fields -isLayout
+    $AssetLayout.asset_layout.add('fields', $validatedFields)
     #$AssetLayout.asset_layout.add('active', $Active)
 
     if ($IncludePasswords) {

--- a/HuduAPI/Public/New-HuduAssetLayout.ps1
+++ b/HuduAPI/Public/New-HuduAssetLayout.ps1
@@ -119,7 +119,7 @@ function New-HuduAssetLayout {
     $AssetLayout.asset_layout.add('icon', $Icon)
     $AssetLayout.asset_layout.add('color', $Color)
     $AssetLayout.asset_layout.add('icon_color', $IconColor)
-    $validatedFields = $Fields | Remove-UnderscoresInFields -isLayout
+    $validatedFields = $Fields | Remove-UnderscoresInFields -NewLayout
     $AssetLayout.asset_layout.add('fields', $validatedFields)
     #$AssetLayout.asset_layout.add('active', $Active)
 

--- a/HuduAPI/Public/New-HuduAssetLayout.ps1
+++ b/HuduAPI/Public/New-HuduAssetLayout.ps1
@@ -152,9 +152,7 @@ function New-HuduAssetLayout {
     Write-Verbose $JSON
 
     if ($PSCmdlet.ShouldProcess($Name)) {
-        $result = Invoke-HuduRequest -Method post -Resource '/api/v1/asset_layouts' -Body $JSON
-        $NewLayout = Get-HuduAssetLayouts -id $($result.asset_layout.id ?? $result.id)
-        Add-HuduAssetLayoutsToCache -Layout $($NewLayout.asset_layout ?? $NewLayout)
-        return $result
+        Set-LayoutsCacheMarkedDirty
+        Invoke-HuduRequest -Method post -Resource '/api/v1/asset_layouts' -Body $JSON
     }
 }

--- a/HuduAPI/Public/New-HuduAssetLayout.ps1
+++ b/HuduAPI/Public/New-HuduAssetLayout.ps1
@@ -119,7 +119,7 @@ function New-HuduAssetLayout {
     $AssetLayout.asset_layout.add('icon', $Icon)
     $AssetLayout.asset_layout.add('color', $Color)
     $AssetLayout.asset_layout.add('icon_color', $IconColor)
-    $validatedFields = Remove-UnderscoresInFields -Fields $Fields -isLayout
+    $validatedFields = $Fields | Remove-UnderscoresInFields -isLayout
     $AssetLayout.asset_layout.add('fields', $validatedFields)
     #$AssetLayout.asset_layout.add('active', $Active)
 

--- a/HuduAPI/Public/Set-HuduAsset.ps1
+++ b/HuduAPI/Public/Set-HuduAsset.ps1
@@ -104,7 +104,8 @@ function Set-HuduAsset {
         }
     
         if ($Fields) {
-            $validatedFields = $Fields | Remove-UnderscoresInFields
+            $validatedFields = Convert-AssetFieldsToCanonical -Fields $Fields -AssetLayoutId $AssetLayoutId `
+                                    -DropUnmatched -DropNull
             $Asset.asset.custom_fields = $validatedFields
         }
     

--- a/HuduAPI/Public/Set-HuduAsset.ps1
+++ b/HuduAPI/Public/Set-HuduAsset.ps1
@@ -105,7 +105,7 @@ function Set-HuduAsset {
     
         if ($Fields) {
             $validatedFields = Convert-AssetFieldsToCanonical -Fields $Fields -AssetLayoutId $AssetLayoutId `
-                                    -DropUnmatched -DropNull
+                                    -DropUnmatched
             $Asset.asset.custom_fields = $validatedFields
         }
     

--- a/HuduAPI/Public/Set-HuduAsset.ps1
+++ b/HuduAPI/Public/Set-HuduAsset.ps1
@@ -104,7 +104,7 @@ function Set-HuduAsset {
         }
     
         if ($Fields) {
-            $validatedFields = Get-ValidatedAssetFields -Fields $Fields -AssetLayoutId $AssetLayoutId
+            $validatedFields = $Fields | Remove-UnderscoresInFields
             $Asset.asset.custom_fields = $validatedFields
         }
     

--- a/HuduAPI/Public/Set-HuduAsset.ps1
+++ b/HuduAPI/Public/Set-HuduAsset.ps1
@@ -104,7 +104,8 @@ function Set-HuduAsset {
         }
     
         if ($Fields) {
-            $Asset.asset.custom_fields = $Fields
+            $validatedFields = Get-ValidatedAssetFields -Fields $Fields -AssetLayoutId $AssetLayoutId
+            $Asset.asset.custom_fields = $validatedFields
         }
     
         if ($Slug) {

--- a/HuduAPI/Public/Set-HuduAssetLayout.ps1
+++ b/HuduAPI/Public/Set-HuduAssetLayout.ps1
@@ -117,7 +117,7 @@ function Set-HuduAssetLayout {
             Default { throw "Invalid field type: $($field.'field_type') found in field $($field.name)" }
         }
     }
-    $Object = Get-SanitizedAssetLayout -AssetLayoutId $Id
+    $Object = Get-HuduAssetLayouts -id $Id
 
     $AssetLayout = [ordered]@{asset_layout = $Object }
     #$AssetLayout.asset_layout = $Object
@@ -140,8 +140,7 @@ function Set-HuduAssetLayout {
 
     if ($Fields) {
         $validatedFields = Remove-UnderscoresInFields -Fields $Fields -isLayout
-        $AssetLayout.asset_layout.fields = $validatedFields
-    }
+        $AssetLayout.asset_layout.fields = $validatedFields    }
 
     if ($IncludePasswords) {
         $AssetLayout.asset_layout.include_passwords = [System.Convert]::ToBoolean($IncludePasswords)
@@ -178,9 +177,7 @@ function Set-HuduAssetLayout {
     $JSON = $AssetLayout | ConvertTo-Json -Depth 10
 
     if ($PSCmdlet.ShouldProcess($Id)) {
-        $result = Invoke-HuduRequest -Method put -Resource "/api/v1/asset_layouts/$Id" -Body $JSON
-        $NewLayout = Get-HuduAssetLayouts -id $($result.asset_layout.id ?? $result.id)
-        Add-HuduAssetLayoutsToCache -Layout $($NewLayout.asset_layout ?? $NewLayout)
-        return $result
+        Set-LayoutsCacheMarkedDirty
+        Invoke-HuduRequest -Method put -Resource "/api/v1/asset_layouts/$Id" -Body $JSON
     }
 }

--- a/HuduAPI/Public/Set-HuduAssetLayout.ps1
+++ b/HuduAPI/Public/Set-HuduAssetLayout.ps1
@@ -140,7 +140,7 @@ function Set-HuduAssetLayout {
 
     if ($Fields) {
         $validatedFields = $Fields | Remove-UnderscoresInFields -isLayout
-        $AssetLayout.asset_layout.fields = $validatedFields    
+        $AssetLayout.asset_layout.fields = $validatedFields
     }
 
     if ($IncludePasswords) {
@@ -172,7 +172,7 @@ function Set-HuduAssetLayout {
     }
 
     if ($Active) {
-        $AssetLayout.asset_layout.active = [System.Convert]::ToBoolean($Active)
+        $AssetLayout.asset_layout.active = $([System.Convert]::ToBoolean($Active))
     }
 
     $JSON = $AssetLayout | ConvertTo-Json -Depth 10

--- a/HuduAPI/Public/Set-HuduAssetLayout.ps1
+++ b/HuduAPI/Public/Set-HuduAssetLayout.ps1
@@ -139,8 +139,9 @@ function Set-HuduAssetLayout {
     }
 
     if ($Fields) {
-        $validatedFields = Remove-UnderscoresInFields -Fields $Fields -isLayout
-        $AssetLayout.asset_layout.fields = $validatedFields    }
+        $validatedFields = $Fields | Remove-UnderscoresInFields -isLayout
+        $AssetLayout.asset_layout.fields = $validatedFields    
+    }
 
     if ($IncludePasswords) {
         $AssetLayout.asset_layout.include_passwords = [System.Convert]::ToBoolean($IncludePasswords)

--- a/HuduAPI/Public/Set-HuduAssetLayout.ps1
+++ b/HuduAPI/Public/Set-HuduAssetLayout.ps1
@@ -118,6 +118,7 @@ function Set-HuduAssetLayout {
         }
     }
     $Object = Get-HuduAssetLayouts -id $Id
+    $object = $object.asset_layout ?? $object
 
     $AssetLayout = [ordered]@{asset_layout = $Object }
     #$AssetLayout.asset_layout = $Object

--- a/HuduAPI/Public/Set-HuduAssetLayout.ps1
+++ b/HuduAPI/Public/Set-HuduAssetLayout.ps1
@@ -178,6 +178,9 @@ function Set-HuduAssetLayout {
     $JSON = $AssetLayout | ConvertTo-Json -Depth 10
 
     if ($PSCmdlet.ShouldProcess($Id)) {
-        Invoke-HuduRequest -Method put -Resource "/api/v1/asset_layouts/$Id" -Body $JSON
+        $result = Invoke-HuduRequest -Method put -Resource "/api/v1/asset_layouts/$Id" -Body $JSON
+        $NewLayout = Get-HuduAssetLayouts -id $($result.asset_layout.id ?? $result.id)
+        Add-HuduAssetLayoutsToCache -Layout $($NewLayout.asset_layout ?? $NewLayout)
+        return $result
     }
 }

--- a/HuduAPI/Public/Set-HuduAssetLayout.ps1
+++ b/HuduAPI/Public/Set-HuduAssetLayout.ps1
@@ -117,7 +117,7 @@ function Set-HuduAssetLayout {
             Default { throw "Invalid field type: $($field.'field_type') found in field $($field.name)" }
         }
     }
-    $Object = Get-HuduAssetLayouts -id $Id
+    $Object = Get-SanitizedAssetLayout -AssetLayoutId $Id
 
     $AssetLayout = [ordered]@{asset_layout = $Object }
     #$AssetLayout.asset_layout = $Object
@@ -139,7 +139,8 @@ function Set-HuduAssetLayout {
     }
 
     if ($Fields) {
-        $AssetLayout.asset_layout.fields = $Fields
+        $validatedFields = Remove-UnderscoresInFields -Fields $Fields -isLayout
+        $AssetLayout.asset_layout.fields = $validatedFields
     }
 
     if ($IncludePasswords) {


### PR DESCRIPTION
- get-huduassetlayouts always fetches live and always updates layouts cache [singular or all]
- set-huduassetlayout and new-huduassetlayout both mark cache dirty/invalid
- the only part of things that uses layouts cache (prefers, but falls back to live) is the field validators for assets. This ensures that we're only making one extra api call every 2 minutes and has no impact on performance.
- layouts cache has a Time-To-Live of 2 minutes and beyond this (or if marked dirty), layouts/assets validation is live-only