### PR TITLE
Feat/globalpasswordfolders and folderremoval

### DIFF
--- a/HuduAPI/Public/New-HuduPasswordFolder.ps1
+++ b/HuduAPI/Public/New-HuduPasswordFolder.ps1
@@ -33,14 +33,19 @@ function New-HuduPasswordFolder {
     [CmdletBinding()]
     param (
         [Parameter(Mandatory)] [string]$Name,
-        [Parameter(Mandatory)][int]$CompanyId,
+        [int]$CompanyId,
         [string]$Description,
         [ValidateSet("all_users","specific")][String]$Security,
         [array]$AllowedGroups)
 
     $password_folder=@{
-        name             = $Name
-        company_id       = $CompanyId
+        name = $Name
+    }
+    if ($PSBoundParameters.ContainsKey('CompanyId')) {
+        $password_folder.company_id = $CompanyId
+    } else {
+        # Assumed to be global password folder if not provided
+        $password_folder.company_id = $null
     }
     if ($Description){
         $password_folder["description"] = $Description

--- a/HuduAPI/Public/Set-HuduPassword.ps1
+++ b/HuduAPI/Public/Set-HuduPassword.ps1
@@ -97,8 +97,7 @@ function Set-HuduPassword {
     $AssetPassword = [ordered]@{asset_password = $Object }
 
     if ($Name) {
-        $AssetPassword.asset_password | Add-Member -MemberType NoteProperty -Name name -Force -Value $Name
-        
+        $AssetPassword.asset_password | Add-Member -MemberType NoteProperty -Name name -Force -Value $Name   
     }
     
     if ($CompanyId) {
@@ -113,40 +112,33 @@ function Set-HuduPassword {
         $AssetPassword.asset_password | Add-Member -MemberType NoteProperty -Name in_portal -Force -Value $InPortal
     }
     
-
-    if ($PasswordableType) {
-        $AssetPassword.asset_password | Add-Member -MemberType NoteProperty -Name passwordable_type -Force -Value $PasswordableType
-    }
-    if ($PasswordableId) {
-        $AssetPassword.asset_password | Add-Member -MemberType NoteProperty -Name passwordable_id -Force -Value $PasswordableId
-    }
-
     if ($OTPSecret) {
         $AssetPassword.asset_password | Add-Member -MemberType NoteProperty -Name otp_secret -Force -Value $OTPSecret
     }
-
     if ($URL) {
         $AssetPassword.asset_password | Add-Member -MemberType NoteProperty -Name url -Force -Value $URL
     }
-
     if ($Username) {
         $AssetPassword.asset_password | Add-Member -MemberType NoteProperty -Name username -Force -Value $Username
     }
-
     if ($Description) {
         $AssetPassword.asset_password | Add-Member -MemberType NoteProperty -Name description -Force -Value $Description
     }
-
     if ($PasswordType) {
         $AssetPassword.asset_password | Add-Member -MemberType NoteProperty -Name password_type -Force -Value $PasswordType
     }
-
-    if ($PasswordFolderId) {
-        $AssetPassword.asset_password | Add-Member -MemberType NoteProperty -Name password_folder_id -Force -Value $PasswordFolderId
-    }
-
     if ($Slug) {
         $AssetPassword.asset_password | Add-Member -MemberType NoteProperty -Name slug -Force -Value $Slug
+    }
+    # Can remove these by setting null
+    if ($PSBoundParameters.ContainsKey('PasswordFolderId')) {
+        $AssetPassword.asset_password | Add-Member -MemberType NoteProperty -Name password_folder_id -Force -Value $PasswordFolderId
+    }
+    if ($PSBoundParameters.ContainsKey('PasswordableType')) {
+        $AssetPassword.asset_password | Add-Member -MemberType NoteProperty -Name passwordable_type -Force -Value $PasswordableType
+    }
+    if ($PSBoundParameters.ContainsKey('PasswordableId')) {
+        $AssetPassword.asset_password | Add-Member -MemberType NoteProperty -Name passwordable_id -Force -Value $PasswordableId
     }
 
     $JSON = $AssetPassword | ConvertTo-Json -Depth 10

--- a/HuduAPI/Public/Set-HuduPasswordFolder.ps1
+++ b/HuduAPI/Public/Set-HuduPasswordFolder.ps1
@@ -43,9 +43,10 @@ function Set-HuduPasswordFolder {
     $updatePasswordFolder=@{
         name        = $(if ($Name) {$Name} else {$passwordFolder.name})
         description = $(if ($Description) {$Description} else {$passwordFolder.description})
-        company_id = $passwordFolder.company_id
     }
-
+    if ($passwordFolder.company_id){
+        $updatePasswordFolder.company_id = $passwordFolder.company_id
+    }
     if (($AllowedGroups -and $AllowedGroups -ne $passwordFolder.allowed_groups) -or ($security -and $security -eq "specific")){
         $updatePasswordFolder["security"] = $security
         $allGroups = $(Get-HuduGroups).id


### PR DESCRIPTION
this allows for removal of passwordable type, passwordable id, passwordfolderid, as well as creating global password folders; assumes that for password folders, company_id may not be at all present