### PR TITLE
removed this warning in get-lists; not needed

### DIFF
--- a/HuduAPI/Public/Get-HuduLists.ps1
+++ b/HuduAPI/Public/Get-HuduLists.ps1
@@ -43,7 +43,7 @@ function Get-HuduLists {
         if ($match) {
             return $match
         }
-        Write-Warning "No list found with name '$Name'"
+        # Write-Warning "No list found with name '$Name'"
         return $null
     }
 


### PR DESCRIPTION
Removed warning in get-lists (by name)
