### PR TITLE
Reducing page-size on activity logs. These include more information t…

### DIFF
--- a/HuduAPI/Public/Get-HuduActivityLogs.ps1
+++ b/HuduAPI/Public/Get-HuduActivityLogs.ps1
@@ -67,7 +67,7 @@ function Get-HuduActivityLogs {
         Params   = $Params
     }
 
-    $AllActivity = Invoke-HuduRequestPaginated -HuduRequest $HuduRequest
+    $AllActivity = Invoke-HuduRequestPaginated -HuduRequest $HuduRequest -PageSize 200
 
     if ($EndDate) {
         $AllActivity = $AllActivity | Where-Object { $([DateTime]::Parse($_.created_at)) -le $EndDate }


### PR DESCRIPTION
Activity logs have more information than ever and a page size of 1000 is often not 'loved' by nginx when it does include lots of data- specifically versioning information
