### PR TITLE
Chore/standardize folderparams

### DIFF
--- a/Docs/Get-HuduFolders.md
+++ b/Docs/Get-HuduFolders.md
@@ -13,8 +13,8 @@ Get a list of Folders
 ## SYNTAX
 
 ```
-Get-HuduFolders [[-Id] <Int32>] [[-Name] <String>] [[-CompanyId] <Int32>] [-ProgressAction <ActionPreference>]
- [<CommonParameters>]
+Get-HuduFolders [[-Id] <Int32>] [[-Name] <String>] [[-CompanyId] <Int32>] [[-folderType] <String>]
+ [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -70,6 +70,22 @@ Aliases: company_id
 Required: False
 Position: 3
 Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -folderType
+Filter by folder_type.
+Accepts "article" or "photo", default is "article"
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: folder_type
+
+Required: False
+Position: 4
+Default value: Article
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/Docs/New-HuduFolder.md
+++ b/Docs/New-HuduFolder.md
@@ -106,12 +106,14 @@ Accept wildcard characters: False
 ```
 
 ### -folderType
-{{ Fill folderType Description }}
+Folder type.
+Accepts "article" or "photo".
+Default is "article".
 
 ```yaml
 Type: String
 Parameter Sets: (All)
-Aliases:
+Aliases: folder_type
 
 Required: False
 Position: 6

--- a/Docs/Set-HuduFolder.md
+++ b/Docs/Set-HuduFolder.md
@@ -13,7 +13,7 @@ Update a Folder
 ## SYNTAX
 
 ```
-Set-HuduFolder [-Id] <Int32> [-Name] <String> [[-Icon] <String>] [[-Description] <String>]
+Set-HuduFolder [-Id] <Int32> [[-Name] <String>] [[-Icon] <String>] [[-Description] <String>]
  [[-ParentFolderId] <Int32>] [[-CompanyId] <Int32>] [-ProgressAction <ActionPreference>] [-WhatIf] [-Confirm]
  [<CommonParameters>]
 ```
@@ -53,7 +53,7 @@ Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 2
 Default value: None
 Accept pipeline input: False

--- a/HuduAPI/Public/Get-HuduFolders.ps1
+++ b/HuduAPI/Public/Get-HuduFolders.ps1
@@ -15,26 +15,33 @@ function Get-HuduFolders {
     .PARAMETER CompanyId
     Filter by company_id
 
+    .PARAMETER folderType
+    Filter by folder_type. Accepts "article" or "photo", default is "article"
+
     .EXAMPLE
     Get-HuduFolders
 
     #>
     [CmdletBinding()]
     Param (
-        [Int]$Id = '',
-        [String]$Name = '',
+        [Nullable[int]]$Id,
+        [String]$Name,
         [Alias('company_id')]
-        [Int]$CompanyId = ''
+        [Nullable[int]]$CompanyId,
+        [ValidateSet("article","photo", ignoreCase = $true)]
+        [Alias('folder_type')]
+        [string]$folderType="article"
     )
 
-    if ($id) {
+    if ($PSBoundParameters.ContainsKey('id')) {
         $Folder = Invoke-HuduRequest -Method get -Resource "/api/v1/folders/$id"
         return $Folder.Folder
     } else {
         $Params = @{}
 
-        if ($CompanyId) { $Params.company_id = $CompanyId }
-        if ($Name) { $Params.name = $Name }
+        if ($PSBoundParameters.ContainsKey('CompanyId')) { $Params.company_id = $CompanyId }
+        if ($PSBoundParameters.ContainsKey('Name')) { $Params.name = $Name }
+        if ($PSBoundParameters.ContainsKey('folderType')) { $Params.folder_type = "$folderType".ToLower() }
 
         $HuduRequest = @{
             Method   = 'GET'

--- a/HuduAPI/Public/Get-HuduFolders.ps1
+++ b/HuduAPI/Public/Get-HuduFolders.ps1
@@ -41,7 +41,7 @@ function Get-HuduFolders {
 
         if ($PSBoundParameters.ContainsKey('CompanyId')) { $Params.company_id = $CompanyId }
         if ($PSBoundParameters.ContainsKey('Name')) { $Params.name = $Name }
-        if ($PSBoundParameters.ContainsKey('folderType')) { $Params.folder_type = "$folderType".ToLower() }
+        $Params.folder_type = "$folderType".ToLower()
 
         $HuduRequest = @{
             Method   = 'GET'

--- a/HuduAPI/Public/Initialize-HuduFolder.ps1
+++ b/HuduAPI/Public/Initialize-HuduFolder.ps1
@@ -3,21 +3,33 @@ function Initialize-HuduFolder {
     param(
         [String[]]$FolderPath,
         [Alias('company_id')]
-        [int]$CompanyId
+        [Nullable[int]]$CompanyId
     )
 
-    if ($CompanyId) {
+    if ($null -ne $CompanyId) {
         $FolderMap = Get-HuduFolderMap -company_id $CompanyId
     } else {
         $FolderMap = Get-HuduFolderMap
     }
 
-    $CurrentFolder = $Foldermap
+    $CurrentFolder = $FolderMap
     foreach ($Folder in $FolderPath) {
         if ($CurrentFolder.$(Get-HuduFolderCleanName $Folder)) {
             $CurrentFolder = $CurrentFolder.$(Get-HuduFolderCleanName $Folder)
         } else {
-            $CurrentFolder = (New-HuduFolder -Name $Folder -company_id $CompanyID -parent_folder_id $CurrentFolder.id).folder
+            $NewFolderParams = @{
+                Name = $Folder
+            }
+
+            if ($null -ne $CompanyId) {
+                $NewFolderParams.CompanyId = $CompanyId
+            }
+
+            if ($null -ne $CurrentFolder.id) {
+                $NewFolderParams.ParentFolderId = $CurrentFolder.id
+            }
+
+            $CurrentFolder = (New-HuduFolder @NewFolderParams).folder
         }
     }
 

--- a/HuduAPI/Public/New-HuduFolder.ps1
+++ b/HuduAPI/Public/New-HuduFolder.ps1
@@ -29,12 +29,12 @@ function New-HuduFolder {
     Param (
         [Parameter(Mandatory = $true)]
         [String]$Name,
-        [String]$Icon = '',
-        [String]$Description = '',
+        [String]$Icon,
+        [String]$Description,
         [Alias('parent_folder_id')]
-        [Int]$ParentFolderId = '',
+        [Nullable[int]]$ParentFolderId,
         [Alias('company_id')]
-        [Int]$CompanyId = '',
+        [Nullable[int]]$CompanyId,
         [string]$folderType='article'
     )
 
@@ -42,25 +42,23 @@ function New-HuduFolder {
 
     $Folder.folder.add('name', $Name)
 
-    if ($Icon) {
+    if ($PSBoundParameters.ContainsKey('Icon')) {
         $Folder.folder.add('icon', $Icon)
     }
 
-    if ($Description) {
+    if ($PSBoundParameters.ContainsKey('Description')) {
         $Folder.folder.add('description', $Description)
     }
 
-    if ($ParentFolderId) {
+    if ($PSBoundParameters.ContainsKey('ParentFolderId')) {
         $Folder.folder.add('parent_folder_id', $ParentFolderId)
     }
 
-    if ($CompanyId) {
+    if ($PSBoundParameters.ContainsKey('CompanyId')) {
         $Folder.folder.add('company_id', $CompanyId)
     }
 
-    if ($FolderType) {
-        $Folder.folder.add('folder_type', $FolderType)
-    }
+    $Folder.folder.add('folder_type', $FolderType)
 
     $JSON = $Folder | ConvertTo-Json
 

--- a/HuduAPI/Public/New-HuduFolder.ps1
+++ b/HuduAPI/Public/New-HuduFolder.ps1
@@ -21,6 +21,9 @@ function New-HuduFolder {
     .PARAMETER CompanyId
     Company id
 
+    .PARAMETER folderType
+    Folder type. Accepts "article" or "photo". Default is "article".
+
     .EXAMPLE
     New-HuduFolder -Name 'Test folder' -CompanyId 1
 
@@ -35,6 +38,8 @@ function New-HuduFolder {
         [Nullable[int]]$ParentFolderId,
         [Alias('company_id')]
         [Nullable[int]]$CompanyId,
+        [ValidateSet("article","photo", ignoreCase = $true)]
+        [Alias('folder_type')]
         [string]$folderType='article'
     )
 
@@ -58,7 +63,7 @@ function New-HuduFolder {
         $Folder.folder.add('company_id', $CompanyId)
     }
 
-    $Folder.folder.add('folder_type', $FolderType)
+    $Folder.folder.add('folder_type', "$FolderType".ToLower())
 
     $JSON = $Folder | ConvertTo-Json
 

--- a/HuduAPI/Public/Set-HuduFolder.ps1
+++ b/HuduAPI/Public/Set-HuduFolder.ps1
@@ -33,7 +33,6 @@ function Set-HuduFolder {
         [Parameter(Mandatory = $true)]
         [Int]$Id,
 
-        [Parameter(Mandatory = $true)]
         [String]$Name,
 
         [String]$Icon,
@@ -47,24 +46,38 @@ function Set-HuduFolder {
         [Nullable[int]]$CompanyId
     )
 
+    $folderObject = get-hudufolders -id $id; $folderobject = $folderobject.folder ?? $folderobject
+
     $Folder = [ordered]@{folder = [ordered]@{} }
 
-    $Folder.folder.add('name', $Name)
+    if ($PSBoundParameters.ContainsKey('Name')) {
+        $Folder.folder.add('name', $Name)
+    } else {
+        $Folder.folder.add('name', $folderObject.name)
+    }
 
     if ($PSBoundParameters.ContainsKey('Icon')) {
         $Folder.folder.add('icon', $Icon)
+    } else {
+        $Folder.folder.add('icon', $folderObject.icon)
     }
 
     if ($PSBoundParameters.ContainsKey('Description')) {
         $Folder.folder.add('description', $Description)
-    } 
+    } else {
+        $Folder.folder.add('description', $folderObject.description)
+    }
 
     if ($PSBoundParameters.ContainsKey('ParentFolderId')) {
         $Folder.folder.add('parent_folder_id', $ParentFolderId)
+    } else {
+        $Folder.folder.add('parent_folder_id', $folderObject.parent_folder_id)
     }
 
     if ($PSBoundParameters.ContainsKey('CompanyId')) {
         $Folder.folder.add('company_id', $CompanyId)
+    } else {
+        $Folder.folder.add('company_id', $folderObject.company_id)
     }
 
     $JSON = $Folder | ConvertTo-Json

--- a/HuduAPI/Public/Set-HuduFolder.ps1
+++ b/HuduAPI/Public/Set-HuduFolder.ps1
@@ -36,34 +36,34 @@ function Set-HuduFolder {
         [Parameter(Mandatory = $true)]
         [String]$Name,
 
-        [String]$Icon = '',
+        [String]$Icon,
 
-        [String]$Description = '',
+        [String]$Description,
 
         [Alias('parent_folder_id')]
-        [Int]$ParentFolderId = '',
+        [Nullable[int]]$ParentFolderId,
 
         [Alias('company_id')]
-        [Int]$CompanyId = ''
+        [Nullable[int]]$CompanyId
     )
 
     $Folder = [ordered]@{folder = [ordered]@{} }
 
     $Folder.folder.add('name', $Name)
 
-    if ($icon) {
+    if ($PSBoundParameters.ContainsKey('Icon')) {
         $Folder.folder.add('icon', $Icon)
     }
 
-    if ($Description) {
+    if ($PSBoundParameters.ContainsKey('Description')) {
         $Folder.folder.add('description', $Description)
-    }
+    } 
 
-    if ($ParentFolderId) {
+    if ($PSBoundParameters.ContainsKey('ParentFolderId')) {
         $Folder.folder.add('parent_folder_id', $ParentFolderId)
     }
 
-    if ($CompanyId) {
+    if ($PSBoundParameters.ContainsKey('CompanyId')) {
         $Folder.folder.add('company_id', $CompanyId)
     }
 

--- a/HuduAPI/Public/Set-HuduFolder.ps1
+++ b/HuduAPI/Public/Set-HuduFolder.ps1
@@ -46,7 +46,7 @@ function Set-HuduFolder {
         [Nullable[int]]$CompanyId
     )
 
-    $folderObject = get-hudufolders -id $id; $folderobject = $folderobject.folder ?? $folderobject
+    $folderObject = get-hudufolders -id $id; $folderobject = $folderobject.folder ?? $folderobject;
 
     $Folder = [ordered]@{folder = [ordered]@{} }
 

--- a/Tools/Update-Documentation.ps1
+++ b/Tools/Update-Documentation.ps1
@@ -4,6 +4,6 @@
 # New-MarkdownHelp -Module HuduAPI -OutputFolder .\Docs\ -Force
 
 remove-module huduapi -Force
-IMPORT-MODULE C:\Users\Administrator\Documents\GitHub\hapidev\HuduAPI\HuduAPI.psd1
+IMPORT-MODULE C:\Users\Administrator\Documents\GitHub\HuduAPI\HuduAPI\HuduAPI.psd1
 
 New-MarkdownHelp -Module HuduAPI -OutputFolder .\Docs\ -Force

--- a/Tools/Update-Documentation.ps1
+++ b/Tools/Update-Documentation.ps1
@@ -4,6 +4,6 @@
 # New-MarkdownHelp -Module HuduAPI -OutputFolder .\Docs\ -Force
 
 remove-module huduapi -Force
-IMPORT-MODULE C:\Users\Administrator\Documents\GitHub\HuduAPI\HuduAPI\HuduAPI.psd1
+IMPORT-MODULE C:\Users\Administrator\Documents\GitHub\hapidev\HuduAPI\HuduAPI.psd1
 
 New-MarkdownHelp -Module HuduAPI -OutputFolder .\Docs\ -Force


### PR DESCRIPTION
This makes automatic blank-string being casted as int (to 0) more avoidable for article / photo folders.
Furthermore, you can now filter folders via get cmdlet to include photo only or article only. In the interest of not breaking anything, it defaults to article folders only, (previous default expected behavior)